### PR TITLE
修复修改菜单时当前菜单数据没有取回的bug

### DIFF
--- a/rbac-web/src/main/resources/static/menus.html
+++ b/rbac-web/src/main/resources/static/menus.html
@@ -168,12 +168,12 @@
     <shiro:hasPermission values="RBAC_SYSTEM_MENU_EDIT" logical="AND">
     <script>
         function editMenu(_self) {
+            $('input[name="uuid"]').val($(_self).data('uuid'));
             layer.open({
                 type:2,
                 content:[$(_self).data('target'), 'no'],
                 area:['550px', '500px']
             });
-            $('input[name="uuid"]').val($(this).data('uuid'));
         }
     </script>
     </shiro:hasPermission>


### PR DESCRIPTION
修改菜单时，点击修改按钮uuid没有传回Controller。原因是menu.html的js中给uuid隐藏域赋值放在了打开编辑窗体代码的后面。